### PR TITLE
62 als systeem wil ik overlappende data te clusteren op id zodat het als gebruiker makkelijker is om te kunnen zien hoeveel overlappende sessies totaal zijn op een

### DIFF
--- a/Tests/RestFiles/test.rest
+++ b/Tests/RestFiles/test.rest
@@ -1,0 +1,2 @@
+GET http://localhost:8000/api/overlapping-cluster/NLLMS240986798
+###

--- a/backend/data/DbContext.py
+++ b/backend/data/DbContext.py
@@ -364,4 +364,27 @@ class DbContext:
         self.close()
         return result
     
-    
+
+    def get_overlapping_cluster(self, start_cdr_id: str) -> list[dict]:
+        self.connect()
+
+        visited = set()
+        to_visit = [start_cdr_id]
+        cluster = {}
+
+        while to_visit:
+            current_id = to_visit.pop()
+            if current_id in visited:
+                continue
+            visited.add(current_id)
+
+            overlapping = self.get_all_overlapping_for_cdr(current_id)
+            for session in overlapping:
+                cdr_id = session['CDR_ID']
+                if cdr_id not in cluster:
+                    cluster[cdr_id] = session
+                    if cdr_id not in visited:
+                        to_visit.append(cdr_id)
+
+        self.close()
+        return list(cluster.values())

--- a/backend/program.py
+++ b/backend/program.py
@@ -558,6 +558,19 @@ async def get_import_logs():
 
     return list(reversed(parsed_lines))
 
+
+@app.get("/api/overlapping-cluster/{cdr_id}")
+async def get_overlap_cluster(cdr_id: str):
+    try:
+        db = DbContext()
+        result = db.get_overlapping_cluster(cdr_id)
+        return result
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+
+
 def main():
     pass
 

--- a/frontend/src/overlappingSessions/OverlappingModal.tsx
+++ b/frontend/src/overlappingSessions/OverlappingModal.tsx
@@ -25,7 +25,7 @@ const OverlappingModal: React.FC<OverlappingModalProps> = ({ cdrId, onClose }) =
   const [sortConfig, setSortConfig] = useState<{ key: keyof OverlappingSession | null; direction: 'asc' | 'desc' | null }>({ key: null, direction: null });
   
   useEffect(() => {
-    fetch(`http://localhost:8000/api/overlapping-sessions/${cdrId}`)
+    fetch(`http://localhost:8000/api/overlapping-cluster/${cdrId}`)
       .then(res => res.json())
       .then(data => {
         const cleaned = data.map((item: any) => ({


### PR DESCRIPTION
This pull request introduces functionality for identifying and displaying overlapping clusters of sessions based on a given CDR ID. It includes backend API additions, database query logic, and frontend updates to process and display the data. Below are the most significant changes:

### Backend Enhancements:

* **New API Endpoint**: Added a new endpoint `/api/overlapping-cluster/{cdr_id}` in `backend/program.py` to retrieve overlapping clusters of sessions for a given CDR ID. This endpoint uses the `DbContext` method `get_overlapping_cluster` and handles potential exceptions.
* **Database Query Logic**: Implemented `get_overlapping_cluster` in `DbContext.py` to traverse and retrieve all sessions related to a starting CDR ID, ensuring no duplicates and maintaining cluster integrity.

### Frontend Updates:

* **API Integration**: Updated the `OverlappingModal` component in `OverlappingModal.tsx` to fetch data from the new `/api/overlapping-cluster/{cdrId}` endpoint instead of the previous `/api/overlapping-sessions/{cdrId}`.
* **Session Grouping Logic**: Modified the `OverlappingSessions` component in `OverlappingSessions.tsx` to group sessions by `Authentication_ID`, aggregate their `Volume` and `Calculated_Cost`, and calculate the number of unique overlapping CDR IDs. This grouped data is used for filtering and display.

### Testing:

* **New Test Case**: Added a test case in `Tests/RestFiles/test.rest` to verify the functionality of the `/api/overlapping-cluster/{cdr_id}` endpoint.