### PR TITLE
107 style voor de inner inner tabel van de overlappende sessies

### DIFF
--- a/backend/endpoints/overlapping.py
+++ b/backend/endpoints/overlapping.py
@@ -4,14 +4,14 @@ from backend.data.DbContext import DbContext
 router = APIRouter()
 
 
-@router.get("/api/overlapping-sessions")
-async def get_overlapping_sessions():
-    try:
-        db = DbContext()
-        sessions = db.get_overlapping_sessions()
-        return sessions
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+# @router.get("/api/overlapping-sessions")
+# async def get_overlapping_sessions():
+#     try:
+#         db = DbContext()
+#         sessions = db.get_overlapping_sessions()
+#         return sessions
+#     except Exception as e:
+#         raise HTTPException(status_code=500, detail=str(e))
 
 
 # Endpoit die Authentication_ID, ClusterCount (aantal unieke CDR_IDs in het cluster), TotalVolume, TotalCost haalt
@@ -32,12 +32,12 @@ async def get_overlapping_sessions_by_auth_id(auth_id: str):
         raise HTTPException(status_code=500, detail=f"Error fetching overlapping sessions: {str(e)}")
 
 
-# Endpoint die het hele cluster per Authentication_ID telt 
-@router.get('/api/overlapping-cluster-count')
-async def get_overlapping_cluster_count():
-    db = DbContext()
-    result = db.get_overlapping_cluster_count()
-    return result
+# # Endpoint die het hele cluster per Authentication_ID telt 
+# @router.get('/api/overlapping-cluster-count')
+# async def get_overlapping_cluster_count():
+#     db = DbContext()
+#     result = db.get_overlapping_cluster_count()
+#     return result
 
 
 # Endpoit dat de details ophaalt van overlappende CDR’s voor een specifieke CDR_ID.

--- a/frontend/src/overlappingSessions/OverlappingDetailsModal.css
+++ b/frontend/src/overlappingSessions/OverlappingDetailsModal.css
@@ -1,0 +1,34 @@
+.details-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.7); /* Donkerder overlay dan normaal */
+  z-index: 2000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding-top: 40px;
+  padding-bottom: 60px;
+}
+
+.details-modal-content {
+  background-color: white;
+  padding: 25px;
+  border-radius: 10px;
+  max-width: 1200px !important;
+  width: 90%;
+  max-height: 85%;
+  overflow-y: auto;
+  position: relative;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
+  border: 3px solid #1976d2; /* Blauwe rand voor onderscheid */
+}
+
+.details-modal-title {
+  font-size: 1.3rem;
+  font-weight: 600;
+  text-align: center;
+  margin-bottom: 20px;
+}

--- a/frontend/src/overlappingSessions/OverlappingDetailsModal.tsx
+++ b/frontend/src/overlappingSessions/OverlappingDetailsModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import './OverlappingModal.css';  // Hergebruik de bestaande CSS
+import './OverlappingDetailsModal.css';
 
 interface OverlappingSession {
   CDR_ID: string;
@@ -41,10 +41,10 @@ const OverlappingDetailsModal: React.FC<OverlappingDetailsModalProps> = ({ cdrId
   const formatDate = (value: string) => new Date(value).toLocaleString();
 
   return (
-    <div className="modal-overlay">
-      <div className="modal-content">
+    <div className="details-modal-overlay">
+      <div className="details-modal-content">
         <button className="modal-close" onClick={onClose}>×</button>
-        <h2 className="modal-title">Details for CDR: {cdrId}</h2>
+        <h2 className="details-modal-title">Details for CDR: {cdrId}</h2>
         {loading ? (
           <p className="modal-loading">Loading...</p>
         ) : details.length === 0 ? (

--- a/frontend/src/overlappingSessions/OverlappingModal.css
+++ b/frontend/src/overlappingSessions/OverlappingModal.css
@@ -9,13 +9,15 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    padding-top: 30px;
+    padding-bottom: 60px;
   }
   
   .modal-content {
     background-color: white;
     padding: 30px;
     border-radius: 8px;
-    max-width: 1200px !important;
+    max-width: 1300px !important;
     width: 100%;
     max-height: 90%;
     overflow-y: auto;


### PR DESCRIPTION
This pull request includes changes to both the backend and frontend to improve functionality and styling for overlapping session handling. Key updates include deprecating unused backend endpoints, introducing a new modal styling for better user experience, and updating the frontend to use the new styling.

### Backend Changes:
* **Deprecated Endpoints**: Commented out the `/api/overlapping-sessions` and `/api/overlapping-cluster-count` endpoints in `backend/endpoints/overlapping.py` as they are no longer in use. These endpoints are preserved in comments for reference. [[1]](diffhunk://#diff-f94af932ac204804e3ad129c82ffcc1f6b5648b250af36c6728a9bdee38e785aL7-R14) [[2]](diffhunk://#diff-f94af932ac204804e3ad129c82ffcc1f6b5648b250af36c6728a9bdee38e785aL35-R40)

### Frontend Changes:
* **New Modal Styling**: Added a new CSS file `OverlappingDetailsModal.css` to define a distinct style for the details modal, including a darker overlay, blue border, and improved layout.
* **Updated Modal Component**: Refactored `OverlappingDetailsModal.tsx` to use the new CSS classes for the modal overlay, content, and title, replacing the old styles. [[1]](diffhunk://#diff-3ab63ed14c7e63bfab18bc853f866c9db2c3fe02f32a51ed1476dd70bcd60630L2-R2) [[2]](diffhunk://#diff-3ab63ed14c7e63bfab18bc853f866c9db2c3fe02f32a51ed1476dd70bcd60630L44-R47)
* **Minor Style Adjustments**: Made small tweaks to the existing `OverlappingModal.css` file, such as adjusting padding and increasing the maximum width of the modal.