### PR TITLE
Added some stuff to Charge Point Statistics

### DIFF
--- a/Tests/UnitTests/UserStats/Test_UserFraud.py
+++ b/Tests/UnitTests/UserStats/Test_UserFraud.py
@@ -1,0 +1,60 @@
+import unittest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from backend.program import app
+
+class TestFraudStats(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+        self.mock_fraud_data = [
+            {
+                "Authentication_ID": "USER01",
+                "TransactionCount": 3,
+                "TotalVolume": 75.0,
+                "TotalCost": 35.5
+            },
+            {
+                "Authentication_ID": None,
+                "TransactionCount": 2,
+                "TotalVolume": 20.0,
+                "TotalCost": 8.0
+            }
+        ]
+
+    @patch("backend.fraud_per_user.fraud_per_user.find_unique_authentication_ids_with_fraud")
+    def test_get_auth_ids_with_fraud_success(self, mock_fraud_func):
+        mock_fraud_func.return_value = self.mock_fraud_data
+
+        response = self.client.get("/api/all-authentication-ids-with-fraud")
+
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 2)
+        self.assertIn("Authentication_ID", data[0])
+        self.assertIn("TransactionCount", data[0])
+        self.assertIn("TotalVolume", data[0])
+        self.assertIn("TotalCost", data[0])
+    
+    @patch("backend.fraud_per_user.fraud_per_user.find_unique_authentication_ids_with_specific_fraud")
+    def test_get_specific_fraud_success(self, mock_fraud_func):
+        mock_fraud_func.return_value = self.mock_fraud_data
+
+        response = self.client.get("/api/all-authentication-ids-with-specific-fraud/Reason1")
+
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 2)
+
+        first = data[0]
+        self.assertIn("Authentication_ID", first)
+        self.assertIn("TransactionCount", first)
+        self.assertIn("TotalVolume", first)
+        self.assertIn("TotalCost", first)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tests/UnitTests/UserStats/Test_UserStats.py
+++ b/Tests/UnitTests/UserStats/Test_UserStats.py
@@ -1,77 +1,107 @@
-# import unittest
-# from fastapi.testclient import TestClient
-# from backend.program import app
+import unittest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from backend.program import app
 
-# class TestChargePointStats(unittest.TestCase):
-#     def setUp(self):
-#         self.client = TestClient(app)
-#         self.mock_db_data = [
-#             {
-#                 "Authentication_ID": "USER01",
-#                 "TransactionCount": 5,
-#                 "TotalVolume": 50,
-#                 "TotalCost": 100.50,
-#             },
-#             {
-#                 "Authentication_ID": "USER02",
-#                 "TransactionCount": 8,
-#                 "TotalVolume": 80,
-#                 "TotalCost": 40.75,
-#             }
-#         ]
+class TestUserStats(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+        self.mock_db_data = [
+            {
+                "Authentication_ID": "USER01",
+                "TransactionCount": 3,
+                "TotalVolume": 50,
+                "TotalCost": 100.50,
+            },
+            {
+                "Authentication_ID": "USER02",
+                "TransactionCount": 8,
+                "TotalVolume": 80,
+                "TotalCost": 40.75,
+            }
+        ]
 
-#     def test_get_charge_point_stats_success(self):
-#         # Test the API endpoint
-#         response = self.client.get("/api/all-authentication-ids-with-fraud")
-        
-#         # Assert response
-#         self.assertEqual(response.status_code, 200)
-#         data = response.json()
-#         self.assertIn("results", data)
-#         self.assertIn("total", data)
-        
-#         # Verify data structure
-#         if len(data["results"]) > 0:
-#             first_item = data["results"][0]
-#             self.assertIn("Charge_Point_ID", first_item)
-#             self.assertIn("Charge_Point_Country", first_item)
-#             self.assertIn("transaction_count", first_item)
-#             self.assertIn("total_volume", first_item)
-#             self.assertIn("total_cost", first_item)
+        self.mock_cdr_data = [
+        {
+            "CDR_ID": 101,
+            "Start_datetime": "2025-06-20T10:00:00",
+            "End_datetime": "2025-06-20T11:00:00",
+            "Duration": 60,
+            "Volume": 22.5,
+            "Charge_Point_ID": "CP-001",
+            "Charge_Point_City": "Rotterdam",
+            "Charge_Point_Country": "Netherlands",
+            "Calculated_Cost": 7.50
+        },
+        {
+            "CDR_ID": 102,
+            "Start_datetime": "2025-06-19T15:30:00",
+            "End_datetime": "2025-06-19T16:00:00",
+            "Duration": 30,
+            "Volume": 12.0,
+            "Charge_Point_ID": "CP-002",
+            "Charge_Point_City": "Amsterdam",
+            "Charge_Point_Country": "Netherlands",
+            "Calculated_Cost": 4.00
+        },
+        {
+            "CDR_ID": 103,
+            "Start_datetime": "2025-06-18T09:15:00",
+            "End_datetime": "2025-06-18T09:45:00",
+            "Duration": 30,
+            "Volume": 15.0,
+            "Charge_Point_ID": "CP-003",
+            "Charge_Point_City": "Utrecht",
+            "Charge_Point_Country": "Netherlands",
+            "Calculated_Cost": 5.25
+        }
+    ]
 
-#     def test_get_charge_point_stats_pagination(self):
-#         # Test pagination
-#         response = self.client.get("/api/charge-point-stats?page=1&page_size=1")
-        
-#         # Assert response
-#         self.assertEqual(response.status_code, 200)
-#         data = response.json()
-#         self.assertLessEqual(len(data["results"]), 1)
-#         self.assertIsInstance(data["total"], int)
+    @patch("backend.endpoints.user_stats.DbContext")
+    def test_get_user_stats_success(self, mock_db_class):
+        # Setup the mock to return your mock data
+        mock_db_instance = mock_db_class.return_value
+        mock_db_instance.get_user_stats.return_value = self.mock_db_data
 
-#     def test_get_charge_point_stats_invalid_page(self):
-#         # Test invalid page number
-#         response = self.client.get("/api/charge-point-stats?page=0&page_size=20")
-#         self.assertEqual(response.status_code, 422)  # Validation error
+        response = self.client.get("/api/user-stats")
 
-#     def test_get_charge_point_stats_invalid_page_size(self):
-#         # Test invalid page size
-#         response = self.client.get("/api/charge-point-stats?page=1&page_size=101")
-#         self.assertEqual(response.status_code, 422)  # Validation error
+        self.assertEqual(response.status_code, 200)
 
-#     def test_get_charge_point_stats_data_types(self):
-#         response = self.client.get("/api/charge-point-stats?page=1&page_size=20")
-#         self.assertEqual(response.status_code, 200)
-#         data = response.json()
-        
-#         if len(data["results"]) > 0:
-#             first_item = data["results"][0]
-#             # Verify data types
-#             self.assertIsInstance(first_item["Charge_Point_ID"], str)
-#             self.assertIsInstance(first_item["Charge_Point_Country"], str)
-#             self.assertIsInstance(first_item["transaction_count"], int)
-#             self.assertIsInstance(first_item["total_volume"], (int, float))
-#             self.assertIsInstance(first_item["total_cost"], (int, float))
+        data = response.json()
 
-# if __name__ == '__main__':
-#     unittest.main()
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 2)
+
+        first_item = data[0]
+        self.assertIn("Authentication_ID", first_item)
+        self.assertIn("TransactionCount", first_item)
+        self.assertIn("TotalVolume", first_item)
+        self.assertIn("TotalCost", first_item)
+
+    @patch("backend.endpoints.user_stats.DbContext")
+    def test_get_user_details_success(self, mock_db_class):
+        mock_db_instance = mock_db_class.return_value
+        mock_db_instance.get_cdrs_by_authentication_id.return_value = self.mock_cdr_data
+
+        response = self.client.get("/api/user-details/USER01")
+
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 3)
+
+        first_item = data[0]
+        self.assertIn("CDR_ID", first_item)
+        self.assertIn("Start_datetime", first_item)
+        self.assertIn("End_datetime", first_item)
+        self.assertIn("Duration", first_item)
+        self.assertIn("Volume", first_item)
+        self.assertIn("Charge_Point_ID", first_item)
+        self.assertIn("Charge_Point_City", first_item)
+        self.assertIn("Charge_Point_Country", first_item)
+        self.assertIn("Calculated_Cost", first_item)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/data/DbContext.py
+++ b/backend/data/DbContext.py
@@ -481,3 +481,28 @@ class DbContext:
         rows = cursor.fetchall()
         self.close()
         return [dict(zip(columns, row)) for row in rows]
+    
+    def get_cdrs_by_charge_point_id(self, charge_point_id: str) -> list[dict]:
+        """Returns all CDR rows for a given Charge_Point_ID"""
+        self.connect()
+        query = """
+            SELECT 
+                CDR_ID,
+                Start_datetime,
+                End_datetime,
+                Duration,
+                Volume,
+                Charge_Point_ID,
+                Charge_Point_City,
+                Charge_Point_Country,
+                Calculated_Cost
+            FROM CDR
+            WHERE Charge_Point_ID = ?
+            ORDER BY Start_datetime DESC
+        """
+        cursor = self.connection.cursor()
+        cursor.execute(query, (charge_point_id,))
+        columns = [desc[0] for desc in cursor.description]
+        rows = cursor.fetchall()
+        self.close()
+        return [dict(zip(columns, row)) for row in rows]

--- a/backend/data/DbContext.py
+++ b/backend/data/DbContext.py
@@ -492,7 +492,7 @@ class DbContext:
                 End_datetime,
                 Duration,
                 Volume,
-                Charge_Point_ID,
+                Authentication_ID,
                 Charge_Point_City,
                 Charge_Point_Country,
                 Calculated_Cost

--- a/backend/endpoints/charges.py
+++ b/backend/endpoints/charges.py
@@ -176,7 +176,6 @@ async def get_all_charge_point_stats():
         raise HTTPException(status_code=500, detail=f"Error fetching charge point statistics: {str(e)}")
 
 
-
 @router.get("/api/charge-details/reason/{reason_key}")
 async def get_charge_details_by_reason(reason_key: str):
     db = DbContext()
@@ -193,3 +192,12 @@ async def get_charge_details_by_reason(reason_key: str):
     results = [dict(zip(columns, row)) for row in cursor.fetchall()]
     db.close()
     return results
+
+@router.get("/api/charge-point-details/{ChargeID}")
+async def get_user_details(ChargeID: str):
+    try:
+        db = DbContext()
+        rows = db.get_cdrs_by_charge_point_id(ChargeID)
+        return rows
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error fetching user details: {str(e)}")

--- a/backend/fraud_charge_point/fraud_charge_point.py
+++ b/backend/fraud_charge_point/fraud_charge_point.py
@@ -1,0 +1,90 @@
+from fastapi import APIRouter, HTTPException
+from backend.data.DbContext import DbContext
+router = APIRouter()
+    
+
+@router.get("/api/all-charge-point-ids-with-fraud")
+def get_all_charge_point_ids_with_fraud():
+    try:
+        data = find_unique_charge_point_ids_with_fraud()
+        return data
+    except Exception as e:
+        print(f"Error: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+@router.get("/api/all-charge-point-ids-with-specific-fraud/{reason}")
+def get_all_charge_point_ids_with_specific_fraud(reason: str):
+    try:
+        data = find_unique_charge_point_ids_with_specific_fraud(reason)
+        return data
+    except Exception as e:
+        print(f"Error: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+def find_unique_charge_point_ids_with_fraud():
+    db = DbContext()
+    db.connect()
+    cursor = db.connection.cursor()
+
+    query = """
+        SELECT 
+            Charge_Point_ID,
+            Charge_Point_Country,
+            COUNT(*) AS transaction_count,
+            SUM(Volume) AS total_volume,
+            SUM(Calculated_Cost) AS total_cost
+        FROM CDR
+        WHERE 
+            Charge_Point_ID IN (
+                SELECT DISTINCT Charge_Point_ID
+                FROM CDR
+                WHERE CDR_ID IN (SELECT CDR_ID FROM FraudCase)
+            )
+            OR Charge_Point_ID IS NULL
+        GROUP BY Charge_Point_ID, Charge_Point_Country
+        ORDER BY Charge_Point_ID
+    """
+
+    cursor.execute(query)
+    rows = cursor.fetchall()
+    columns = [desc[0] for desc in cursor.description]
+    result = [dict(zip(columns, row)) for row in rows]
+
+    db.close()
+    return result
+
+def find_unique_charge_point_ids_with_specific_fraud(reason):
+    db = DbContext()
+    db.connect()
+    cursor = db.connection.cursor()
+
+    query = f"""
+        SELECT 
+            Charge_Point_ID,
+            Charge_Point_Country,
+            COUNT(*) AS transaction_count,
+            SUM(Volume) AS total_volume,
+            SUM(Calculated_Cost) AS total_cost
+        FROM CDR
+        WHERE 
+            Charge_Point_ID IN (
+                SELECT DISTINCT Charge_Point_ID
+                FROM CDR
+                WHERE CDR_ID IN (
+                    SELECT CDR_ID 
+                    FROM FraudCase 
+                    WHERE {reason} IS NOT NULL
+                )
+            )
+            OR Charge_Point_ID IS NULL
+        GROUP BY Charge_Point_ID, Charge_Point_Country
+        ORDER BY Charge_Point_ID
+    """
+
+    cursor.execute(query)
+    rows = cursor.fetchall()
+    columns = [desc[0] for desc in cursor.description]
+    result = [dict(zip(columns, row)) for row in rows]
+
+    db.close()
+    return result

--- a/backend/program.py
+++ b/backend/program.py
@@ -21,6 +21,7 @@ from backend.endpoints.User import router as user_router
 from backend.endpoints.CDR import router as cdr_router
 from backend.endpoints.locations import router as locations_router
 from backend.fraud_per_user.fraud_per_user import router as fraud_per_user_router
+from backend.fraud_charge_point.fraud_charge_point import router as fraud_charge_points_router
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -50,6 +51,7 @@ app.include_router(user_stats_router)
 app.include_router(user_router)
 app.include_router(cdr_router)
 app.include_router(locations_router)
+app.include_router(fraud_charge_points_router)
 
 def start_geocoding_process(db_path: str):
     """Start the geocoding process in a background thread."""

--- a/frontend/src/chargepointstats/ChargePointStatsModal.tsx
+++ b/frontend/src/chargepointstats/ChargePointStatsModal.tsx
@@ -1,0 +1,269 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import '../userStats/UserDetailsModal.css';
+import '../css/UniversalTableCss.css';
+import TableExportButton from '../exportButton/TableExportButton';
+
+/* ──────────────── Types ──────────────── */
+interface CdrDetail {
+  CDR_ID: string;
+  Start_datetime: string;
+  End_datetime: string;
+  Duration: number;
+  Volume: number;
+  Authentication_ID: string;
+  Charge_Point_City: string;
+  Charge_Point_Country: string;
+  Calculated_Cost: number;
+}
+
+interface ChargeModalProps {
+  ChargeID: string;
+  onClose: () => void;
+}
+
+/* ──────────────── Component ──────────────── */
+const UserDetailsModal: React.FC<ChargeModalProps> = ({ ChargeID, onClose }) => {
+  /* Data */
+  const [details, setDetails] = useState<CdrDetail[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  /* Sorting */
+  const [sortConfig, setSortConfig] = useState<{ key: keyof CdrDetail | null; direction: 'asc' | 'desc' | null }>({
+    key: null,
+    direction: null,
+  });
+
+  /* Pagination */
+  const itemsPerPage = 15;
+  const [currentPage, setCurrentPage] = useState(1);
+  const [showInput, setShowInput] = useState<{ left: boolean; right: boolean }>({ left: false, right: false });
+  const [inputValue, setInputValue] = useState('');
+  const navigate = useNavigate();
+
+  /* Fetch */
+  useEffect(() => {
+    setLoading(true);
+    fetch(`http://localhost:8000/api/charge-point-details/${ChargeID}`)
+      .then(res => res.json())
+      .then(data => {
+        const cleaned = data.map((item: any) => ({
+          ...item,
+          Volume: parseFloat((item.Volume ?? '0').toString().replace(',', '.')),
+          Calculated_Cost: parseFloat((item.Calculated_Cost ?? '0').toString().replace(',', '.')),
+        }));
+        setDetails(cleaned);
+      })
+      .finally(() => setLoading(false));
+  }, [ChargeID]);
+
+  /* Helpers */
+  const formatDate = (val: string) => new Date(val).toLocaleString();
+
+  const handleSort = (key: keyof CdrDetail) => {
+    setSortConfig(prev => {
+      if (prev.key !== key) return { key, direction: 'asc' };
+      if (prev.direction === 'asc') return { key, direction: 'desc' };
+      if (prev.direction === 'desc') return { key: null, direction: null };
+      return { key, direction: 'asc' };
+    });
+    setCurrentPage(1);
+  };
+
+  const getSortIndicator = (key: keyof CdrDetail) => {
+    if (sortConfig.key === key) {
+      return sortConfig.direction === 'asc' ? ' ▲' : sortConfig.direction === 'desc' ? ' ▼' : '';
+    }
+    return '';
+  };
+
+  const sortedDetails = useMemo(() => {
+    const arr = [...details];
+    if (sortConfig.key && sortConfig.direction) {
+      arr.sort((a, b) => {
+        const aVal = a[sortConfig.key!] ?? 0;
+        const bVal = b[sortConfig.key!] ?? 0;
+        if (typeof aVal === 'number' && typeof bVal === 'number') {
+          return sortConfig.direction === 'asc' ? aVal - bVal : bVal - aVal;
+        }
+        return 0;
+      });
+    }
+    return arr;
+  }, [details, sortConfig]);
+
+  /* Pagination logic */
+  const totalPages = Math.ceil(sortedDetails.length / itemsPerPage);
+  const indexOfLastItem = currentPage * itemsPerPage;
+  const indexOfFirstItem = indexOfLastItem - itemsPerPage;
+  const currentItems = sortedDetails.slice(indexOfFirstItem, indexOfLastItem);
+
+  const goToPage = (page: number) => {
+    if (page >= 1 && page <= totalPages) {
+      setCurrentPage(page);
+      setShowInput({ left: false, right: false });
+      setInputValue('');
+    }
+  };
+
+  const handleEllipsisClick = (side: 'left' | 'right') => {
+    setShowInput({ left: side === 'left', right: side === 'right' });
+    setInputValue('');
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value.replace(/[^0-9]/g, '');
+    setInputValue(val);
+  };
+
+  const handleInputSubmit = (side: 'left' | 'right') => {
+    const page = Number(inputValue);
+    if (page >= 1 && page <= totalPages) goToPage(page);
+  };
+
+  const getPageNumbers = (): (number | string)[] => {
+    const pages: (number | string)[] = [];
+    if (totalPages <= 7) {
+      for (let i = 1; i <= totalPages; i++) pages.push(i);
+      return pages;
+    }
+    const first = [1, 2, 3];
+    const last = [totalPages - 2, totalPages - 1, totalPages];
+    let start = Math.max(4, currentPage - 1);
+    let end = Math.min(totalPages - 3, currentPage + 1);
+    const middle: number[] = [];
+    for (let i = start; i <= end; i++) middle.push(i);
+
+    const all: (number | string)[] = [...first];
+    if (start > 4) all.push('ellipsis1');
+    for (const p of middle) if (!all.includes(p)) all.push(p);
+    if (end < totalPages - 3) all.push('ellipsis2');
+    for (const p of last) if (!all.includes(p)) all.push(p);
+    return all;
+  };
+
+  /* Export definition */
+  const exportColumns = [
+    { label: 'CDR ID', key: 'CDR_ID' },
+    { label: 'Authentication ID', key: 'Authentication_ID' },
+    { label: 'Start Time', key: 'Start_datetime' },
+    { label: 'End Time', key: 'End_datetime' },
+    { label: 'Duration (min)', key: 'Duration' },
+    { label: 'Volume (kWh)', key: 'Volume' },
+    { label: 'Cost (€)', key: 'Calculated_Cost' },
+    { label: 'City', key: 'Charge_Point_City' },
+    { label: 'Country', key: 'Charge_Point_Country' },
+  ];
+
+  /* Render */
+  return (
+    <div className="modal-overlay">
+      <div className="modal-content">
+        <button className="modal-close" onClick={onClose}>
+          ×
+        </button>
+        <h2 className="modal-title">CDR Details for Charge Point ID: {ChargeID}</h2>
+
+        {loading ? (
+          <p className="modal-loading">Loading...</p>
+        ) : details.length === 0 ? (
+          <p className="modal-empty">No records found.</p>
+        ) : (
+          <>
+            <TableExportButton data={sortedDetails} columns={exportColumns} filename={`cdr_details_${ChargeID}`} format="xlsx" />
+
+            <table className="modal-table">
+              <thead>
+                <tr>
+                  <th>CDR ID</th>
+                  <th>Authentication ID</th>
+                  <th>Start Time</th>
+                  <th>End Time</th>
+                  <th>Duration (min)</th>
+                  <th className="sortable-header" onClick={() => handleSort('Volume')}>
+                    Volume (kWh)
+                    {getSortIndicator('Volume')}
+                  </th>
+                  <th className="sortable-header" onClick={() => handleSort('Calculated_Cost')}>
+                    Cost (€)
+                    {getSortIndicator('Calculated_Cost')}
+                  </th>
+                  <th>City</th>
+                  <th>Country</th>
+                </tr>
+              </thead>
+              <tbody>
+                {currentItems.map(row => (
+                  <tr 
+                    key={row.CDR_ID} 
+                    onClick={() => navigate(`/cdr-details/${row.CDR_ID}`)} 
+                    className="clickable-row"
+                    style={{ cursor: 'pointer' }}
+                  >
+                    <td>{row.CDR_ID}</td>
+                    <td>{row.Authentication_ID}</td>
+                    <td>{formatDate(row.Start_datetime)}</td>
+                    <td>{formatDate(row.End_datetime)}</td>
+                    <td>{row.Duration}</td>
+                    <td>{row.Volume.toFixed(2)}</td>
+                    <td>{row.Calculated_Cost.toFixed(2)}</td>
+                    <td>{row.Charge_Point_City}</td>
+                    <td>{row.Charge_Point_Country}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+
+
+            {/* Pagination */}
+            <div className="pagination-container">
+              <button className="pagination-button" onClick={() => goToPage(currentPage - 1)} disabled={currentPage === 1}>
+                Previous
+              </button>
+
+              {getPageNumbers().map(page =>
+                typeof page === 'number' ? (
+                  <button
+                    key={page}
+                    title={`${page}`}
+                    onClick={() => goToPage(page)}
+                    className={`pagination-button ${page === currentPage ? 'active' : ''}`}
+                  >
+                    {page}
+                  </button>
+                ) : (
+                  <span key={page} className="pagination-ellipsis">
+                    {showInput[page === 'ellipsis1' ? 'left' : 'right'] ? (
+                      <input
+                        type="text"
+                        className="pagination-input"
+                        value={inputValue}
+                        onChange={handleInputChange}
+                        onBlur={() => handleInputSubmit(page === 'ellipsis1' ? 'left' : 'right')}
+                        onKeyDown={e => e.key === 'Enter' && handleInputSubmit(page === 'ellipsis1' ? 'left' : 'right')}
+                        autoFocus
+                      />
+                    ) : (
+                      <span
+                        onClick={() => handleEllipsisClick(page === 'ellipsis1' ? 'left' : 'right')}
+                        style={{ cursor: 'pointer' }}
+                      >
+                        ...
+                      </span>
+                    )}
+                  </span>
+                )
+              )}
+
+              <button className="pagination-button" onClick={() => goToPage(currentPage + 1)} disabled={currentPage === totalPages}>
+                Next
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default UserDetailsModal;

--- a/frontend/src/chargepointstats/ChargePointStatsTable.api.ts
+++ b/frontend/src/chargepointstats/ChargePointStatsTable.api.ts
@@ -18,4 +18,17 @@ export const fetchChargePointStats = async (): Promise<ChargePointStat[]> => {
     return Array.isArray(data) ? data : [];
 };
 
+export const fetchAllFraudStats = async () => {
+  const res = await fetch('http://localhost:8000/api/all-charge-point-ids-with-fraud');
+  if (!res.ok) throw new Error('Failed to fetch fraud stats');
+  return await res.json();
+};
+
+export const fetchStatsByFraudType = async (reason: string) => {
+  const encodedReason = encodeURIComponent(reason);
+  const res = await fetch(`http://localhost:8000/api/all-charge-point-ids-with-specific-fraud/${encodedReason}`);
+  if (!res.ok) throw new Error(`Failed to fetch stats for reason: ${reason}`);
+  return await res.json();
+};
+
 export { PAGE_SIZE };

--- a/frontend/src/chargepointstats/ChargePointStatsTable.tsx
+++ b/frontend/src/chargepointstats/ChargePointStatsTable.tsx
@@ -3,7 +3,7 @@ import { PAGE_SIZE } from './ChargePointStatsTable.api';
 import { useData } from '../context/DataContext';
 import '../css/UniversalTableCss.css';
 import TableExportButton from '../exportButton/TableExportButton';
-// test
+import ChargePointStatsModal from './ChargePointStatsModal';
 
 interface ChargePointStat {
     Charge_Point_ID: string;
@@ -21,6 +21,8 @@ const ChargePointStatsTable: React.FC = () => {
     const [searchTerm, setSearchTerm] = useState('');
     const [searchField, setSearchField] = useState<'Charge_Point_ID' | 'Charge_Point_Country'>('Charge_Point_ID');
     const [sortConfig, setSortConfig] = useState<{ key: keyof ChargePointStat | null; direction: 'asc' | 'desc' | null }>({ key: null, direction: null });
+    const [selectedChargePointId, setSelectedChargePointId] = useState<string | null>(null);
+    const [showModal, setShowModal] = useState(false);
 
     // Client-side filtering
     const filteredStats = chargePointStats.filter((stat: ChargePointStat) => {
@@ -195,7 +197,14 @@ const ChargePointStatsTable: React.FC = () => {
                             </tr>
                         ) : (
                             currentStats.map((stat: ChargePointStat) => (
-                                <tr key={stat.Charge_Point_ID}>
+                                <tr 
+                                    key={stat.Charge_Point_ID} 
+                                    className="clickable-row" 
+                                    onClick={() => {
+                                        setSelectedChargePointId(stat.Charge_Point_ID);
+                                        setShowModal(true);
+                                    }}
+                                >
                                     <td>{stat.Charge_Point_ID}</td>
                                     <td>{stat.Charge_Point_Country}</td>
                                     <td>{stat.transaction_count}</td>
@@ -259,6 +268,15 @@ const ChargePointStatsTable: React.FC = () => {
                         Next
                     </button>
                 </div>
+            )}
+            {showModal && selectedChargePointId && (
+                <ChargePointStatsModal
+                    ChargeID={selectedChargePointId}
+                    onClose={() => {
+                        setShowModal(false);
+                        setSelectedChargePointId(null);
+                    }}
+                />
             )}
         </div>
     );

--- a/frontend/src/userStats/UserDetailsModal.tsx
+++ b/frontend/src/userStats/UserDetailsModal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import './UserDetailsModal.css';
 import '../css/UniversalTableCss.css';
 import TableExportButton from '../exportButton/TableExportButton';
@@ -38,6 +39,7 @@ const UserDetailsModal: React.FC<UserDetailsModalProps> = ({ authId, onClose }) 
   const [currentPage, setCurrentPage] = useState(1);
   const [showInput, setShowInput] = useState<{ left: boolean; right: boolean }>({ left: false, right: false });
   const [inputValue, setInputValue] = useState('');
+  const navigate = useNavigate();
 
   /* Fetch */
   useEffect(() => {
@@ -192,7 +194,12 @@ const UserDetailsModal: React.FC<UserDetailsModalProps> = ({ authId, onClose }) 
               </thead>
               <tbody>
                 {currentItems.map(row => (
-                  <tr key={row.CDR_ID}>
+                  <tr 
+                    key={row.CDR_ID} 
+                    onClick={() => navigate(`/cdr-details/${row.CDR_ID}`)} 
+                    className="clickable-row"
+                    style={{ cursor: 'pointer' }}
+                  >
                     <td>{row.CDR_ID}</td>
                     <td>{row.Charge_Point_ID}</td>
                     <td>{formatDate(row.Start_datetime)}</td>
@@ -206,6 +213,7 @@ const UserDetailsModal: React.FC<UserDetailsModalProps> = ({ authId, onClose }) 
                 ))}
               </tbody>
             </table>
+
 
             {/* Pagination */}
             <div className="pagination-container">


### PR DESCRIPTION
This pull request introduces several enhancements and new features related to fraud detection, charge point statistics, and user details. The changes include new API endpoints, database queries, unit tests, and frontend components to support these functionalities. Below is a summary of the most important changes grouped by theme.

### Backend Enhancements

#### Fraud Detection:
* Added new API endpoints in `backend/fraud_charge_point/fraud_charge_point.py` to retrieve charge point IDs associated with fraud cases and specific fraud reasons. These endpoints use database queries to aggregate fraud-related statistics.

#### Database Queries:
* Implemented a new method `get_cdrs_by_charge_point_id` in `backend/data/DbContext.py` to fetch detailed charge data for a specific charge point ID.

#### API Endpoints:
* Introduced a new endpoint `/api/charge-point-details/{ChargeID}` in `backend/endpoints/charges.py` to retrieve charge details for a specific charge point ID using the newly added database method.

### Frontend Features

#### Charge Point Statistics Modal:
* Developed a new React component `ChargePointStatsModal.tsx` to display detailed charge point statistics in a modal. This includes sorting, pagination, and data export functionality for charge point data.

### Unit Tests

#### Fraud and User Stats:
* Added unit tests in `Tests/UnitTests/UserStats/Test_UserFraud.py` and `Tests/UnitTests/UserStats/Test_UserStats.py` to validate the new fraud detection and user statistics endpoints. These tests use `unittest.mock` to simulate database interactions. [[1]](diffhunk://#diff-86b46ad6970b0dad77412d16ad85777bfca7452c318b601da1f59d55976427e0R1-R60) [[2]](diffhunk://#diff-af4575cc5425d3269ff8baf0eb852cb7cd6bde6e1a29b05599118b6c93be37fdL1-R107)

### Miscellaneous

#### Router Integration:
* Registered the `fraud_charge_points_router` in `backend/program.py` to enable the new fraud-related endpoints in the application. [[1]](diffhunk://#diff-cc08fc94ca9aa0e6db0da9565e888ec7a40a7e973ff6308d867efe2f99c3a203R24) [[2]](diffhunk://#diff-cc08fc94ca9aa0e6db0da9565e888ec7a40a7e973ff6308d867efe2f99c3a203R54)