### PR TITLE
add an export button for the inner inner table

### DIFF
--- a/frontend/src/overlappingSessions/OverlappingDetailsModal.tsx
+++ b/frontend/src/overlappingSessions/OverlappingDetailsModal.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import './OverlappingDetailsModal.css';
 import '../css/UniversalTableCss.css';
+import TableExportButton from '../exportButton/TableExportButton';
+
 
 interface OverlappingSession {
   CDR_ID: string;
@@ -120,11 +122,30 @@ const OverlappingDetailsModal: React.FC<OverlappingDetailsModalProps> = ({ cdrId
     return allPages;
   };
 
+  const exportColumns = [
+    { label: 'CDR ID', key: 'CDR_ID' },
+    { label: 'Authentication ID', key: 'Authentication_ID' },
+    { label: 'Charge Point ID', key: 'Charge_Point_ID' },
+    { label: 'Start Time', key: 'Start_datetime' },
+    { label: 'End Time', key: 'End_datetime' },
+    { label: 'City', key: 'Charge_Point_City' },
+    { label: 'Country', key: 'Charge_Point_Country' },
+    { label: 'Volume (kWh)', key: 'Volume' },
+    { label: 'Cost (€)', key: 'Calculated_Cost' },
+  ];
+
   return (
     <div className="details-modal-overlay">
       <div className="details-modal-content">
         <button className="modal-close" onClick={onClose}>×</button>
         <h2 className="details-modal-title">Details for CDR: {cdrId}</h2>
+        <TableExportButton
+        data={details}
+        columns={exportColumns}
+        filename={`overlapping_details_${cdrId}`}
+        format="xlsx"
+      />
+
         {loading ? (
           <p className="modal-loading">Loading...</p>
         ) : details.length === 0 ? (


### PR DESCRIPTION
This pull request enhances the `OverlappingDetailsModal` component by introducing a new feature for exporting session details to an Excel file. The changes include importing and integrating a `TableExportButton` component and defining the necessary export configuration.

### New Export Feature:

* **Importing `TableExportButton`**: Added the `TableExportButton` component to enable data export functionality. (`frontend/src/overlappingSessions/OverlappingDetailsModal.tsx`, [frontend/src/overlappingSessions/OverlappingDetailsModal.tsxR5-R6](diffhunk://#diff-3ab63ed14c7e63bfab18bc853f866c9db2c3fe02f32a51ed1476dd70bcd60630R5-R6))
* **Export Configuration**: Defined `exportColumns` to map session details to exportable columns, including fields like `CDR ID`, `Start Time`, and `Cost (€)`. (`frontend/src/overlappingSessions/OverlappingDetailsModal.tsx`, [frontend/src/overlappingSessions/OverlappingDetailsModal.tsxR125-R148](diffhunk://#diff-3ab63ed14c7e63bfab18bc853f866c9db2c3fe02f32a51ed1476dd70bcd60630R125-R148))
* **Integration of Export Button**: Added the `TableExportButton` to the modal, allowing users to export session details as an Excel file with the filename dynamically generated using the `cdrId`. (`frontend/src/overlappingSessions/OverlappingDetailsModal.tsx`, [frontend/src/overlappingSessions/OverlappingDetailsModal.tsxR125-R148](diffhunk://#diff-3ab63ed14c7e63bfab18bc853f866c9db2c3fe02f32a51ed1476dd70bcd60630R125-R148))