### PR TITLE
Add human-readable mapping for fraud reason keys in ChargeDetails and…

### DIFF
--- a/frontend/src/ChargeDetails/ChargeDetail.tsx
+++ b/frontend/src/ChargeDetails/ChargeDetail.tsx
@@ -32,6 +32,17 @@ const ChargeDetails: React.FC = () => {
     const navigate = useNavigate();
     const itemsPerPage = 15;
 
+    // Map reason keys to human-readable names (matching Fraude_detectie.py)
+    const reasonNameMap: { [key: string]: string } = {
+        Reason1: 'High volume in short duration',
+        Reason2: 'Unusual cost per kWh',
+        Reason3: 'Rapid consecutive sessions',
+        Reason4: 'Overlapping sessions',
+        Reason5: 'Repeated behavior',
+        Reason6: 'Data integrity violation',
+        Reason7: 'Impossible travel',
+    };
+
     const filteredStats = data.filter((stat: ChargeDetail) => {
         const fieldMap: Record<typeof searchField, keyof ChargeDetail> = {
             CDR_ID: 'CDR_ID',
@@ -212,7 +223,7 @@ const ChargeDetails: React.FC = () => {
     return (
         <div className="table-container">
             <div className= 'table-search-wrapper'>
-                <h2>Fraud Cases for {reasonKey}</h2>
+                <h2>Fraud Cases for {reasonNameMap[reasonKey as keyof typeof reasonNameMap] || reasonKey}</h2>
                 <div>
 
                 <TableExportButton

--- a/frontend/src/home/Home.tsx
+++ b/frontend/src/home/Home.tsx
@@ -34,7 +34,19 @@ const Home: React.FC = () => {
                     chartInstanceRef.current.destroy();
                 }
 
-                const labels = Object.keys(fraudReasons[0].reason_percentages || {});
+                // Map reason keys to human-readable names (matching Fraude_detectie.py)
+                const reasonNameMap: { [key: string]: string } = {
+                    Reason1: 'High volume in short duration',
+                    Reason2: 'Unusual cost per kWh',
+                    Reason3: 'Rapid consecutive sessions',
+                    Reason4: 'Overlapping sessions',
+                    Reason5: 'Repeated behavior',
+                    Reason6: 'Data integrity violation',
+                    Reason7: 'Impossible travel',
+                };
+
+                const labelsRaw = Object.keys(fraudReasons[0].reason_percentages || {});
+                const labels = labelsRaw.map(key => reasonNameMap[key] || key);
                 const percentages = Object.values(fraudReasons[0].reason_percentages || {});
                 const counts = Object.values(fraudReasons[0].reason_counts || {});
 
@@ -105,7 +117,7 @@ const Home: React.FC = () => {
                         onClick: (event, elements) => {
                             if (elements && elements.length > 0) {
                                 const index = elements[0].index;
-                                const reasonKey = labels[index];
+                                const reasonKey = labelsRaw[index]; // Use the original key for navigation
                                 navigate(`/charge-details/reason/${reasonKey}`);
                             }
                         },


### PR DESCRIPTION
This pull request introduces a mapping of fraud reason keys to human-readable names across multiple components in the frontend to improve clarity and consistency in the UI. The changes primarily affect the `ChargeDetails` and `Home` components by implementing this mapping and ensuring proper usage of the original keys for navigation.

### Enhancements to fraud reason key handling:

* **Mapping reason keys to human-readable names in `ChargeDetails`:**
  - Added a `reasonNameMap` object to map fraud reason keys to descriptive names.
  - Updated the table header to display human-readable names instead of raw keys by using the `reasonNameMap`.

* **Mapping reason keys to human-readable names in `Home`:**
  - Added a `reasonNameMap` object for mapping fraud reason keys to descriptive names, similar to `ChargeDetails`.
  - Updated chart labels to use human-readable names while preserving the original keys (`labelsRaw`) for navigation purposes. [[1]](diffhunk://#diff-08321f07f6ec5cb8129ed642a481b471a2f5b07c5759dab5c021f1c0ee7aa442L37-R49) [[2]](diffhunk://#diff-08321f07f6ec5cb8129ed642a481b471a2f5b07c5759dab5c021f1c0ee7aa442L108-R120)